### PR TITLE
init ScalableGNN

### DIFF
--- a/torch_geometric_autoscale/__init__.py
+++ b/torch_geometric_autoscale/__init__.py
@@ -15,6 +15,7 @@ from .pool import AsyncIOPool  # noqa
 from .metis import metis, permute  # noqa
 from .utils import compute_micro_f1, gen_masks, dropout  # noqa
 from .loader import SubgraphLoader, EvalSubgraphLoader  # noqa
+from .models import ScalableGNN
 
 __all__ = [
     'get_data',
@@ -27,5 +28,6 @@ __all__ = [
     'dropout',
     'SubgraphLoader',
     'EvalSubgraphLoader',
+    'ScalableGNN',
     '__version__',
 ]


### PR DESCRIPTION
Currently, the example in README.md could not be run because one could only import ScalableGNN from torch_geometric_autoscale.models. I have imported ScalableGNN to torch_geometric_autoscale so that the example would not fail. Alternatively, one could fix the example code in README.md, but as ScalableGNN is useful in many places, perhaps making it easier to be imported would be better.